### PR TITLE
WifiSetup: If device has Leanback feature specify tv.settings

### DIFF
--- a/src/com/cyanogenmod/setupwizard/setup/WifiSetupPage.java
+++ b/src/com/cyanogenmod/setupwizard/setup/WifiSetupPage.java
@@ -222,6 +222,9 @@ public class WifiSetupPage extends SetupPage {
     private void launchWifiSetup() {
         SetupWizardUtils.tryEnablingWifi(mContext);
         Intent intent = new Intent(SetupWizardApp.ACTION_SETUP_WIFI);
+        if (SetupWizardUtils.hasLeanback(mContext)) {
+            intent.setComponent(SetupWizardUtils.mTvwifisettingsActivity);
+        }
         intent.putExtra(SetupWizardApp.EXTRA_FIRST_RUN, true);
         intent.putExtra(SetupWizardApp.EXTRA_ALLOW_SKIP, true);
         intent.putExtra(SetupWizardApp.EXTRA_USE_IMMERSIVE, true);

--- a/src/com/cyanogenmod/setupwizard/util/SetupWizardUtils.java
+++ b/src/com/cyanogenmod/setupwizard/util/SetupWizardUtils.java
@@ -225,4 +225,13 @@ public class SetupWizardUtils {
         context.getPackageManager().setComponentEnabledSetting(component,
                 PackageManager.COMPONENT_ENABLED_STATE_ENABLED, PackageManager.DONT_KILL_APP);
     }
+
+    public static boolean hasLeanback(Context context) {
+        PackageManager packageManager = context.getPackageManager();
+        return packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK);
+    }
+
+    public static final ComponentName mTvwifisettingsActivity =
+            new ComponentName("com.android.tv.settings",
+                    "com.android.tv.settings.connectivity.setup.WifiSetupActivity");
 }


### PR DESCRIPTION
Fugu has both com.android.settings and com.android.tv.settings so
currently it brings up a selector dialog for how to handle the wifi
intent, which leads to "Activity is launching as a new task, so
cancelling activity result." Fix this by passing the component name
in the intent if FEATURE_LEANBACK is present

Change-Id: I470590315d3f95a32b7796dd4a916a543392fcd6