### PR TITLE
Disable the CyanogenServicesPage if FEATURE_LEANBACK detected

### DIFF
--- a/src/com/cyanogenmod/setupwizard/setup/CMSetupWizardData.java
+++ b/src/com/cyanogenmod/setupwizard/setup/CMSetupWizardData.java
@@ -61,7 +61,9 @@ public class CMSetupWizardData extends AbstractSetupData {
         if (SetupWizardUtils.hasGMS(mContext)) {
             pages.add(new GmsAccountPage(mContext, this).setHidden(true));
         }
-        pages.add(new CyanogenServicesPage(mContext, this).setHidden(true));
+        if (!SetupWizardUtils.hasLeanback(mContext)) {
+            pages.add(new CyanogenServicesPage(mContext, this).setHidden(true));
+        }
         pages.add(new CyanogenSettingsPage(mContext, this));
         pages.add(new OtherSettingsPage(mContext, this));
         pages.add(new DateTimePage(mContext, this));


### PR DESCRIPTION
TV devices will not benefit from having a CM account.

Change-Id: I5258a1442c400b35d92c22a2b0e8dcbe3516aead